### PR TITLE
Make reproducible Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM rocker/tidyverse
+FROM rocker/tidyverse:3.5
 
 RUN install2.r --error \
     -r 'http://cran.rstudio.com' \
     httr \
     forecast \
-  && installGithub.r \
-    sicarul/redshiftTools \
-    jwinternheimer/buffer \
   && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
+# Install Github packages
+RUN R -e "devtools::install_github(c('jwinternheimer/buffer', 'sicarul/redshiftTools'), dependencies = T)"
+
 ADD forecast.R forecast.R
+
 CMD ["Rscript", "forecast.R"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-NAME = julheimer/mrr_forecaster:0.1.0
-
-.PHONY: all build run dev
+NAME = bufferapp/mrr-forecaster:0.1.0
 
 all: run
 
@@ -8,7 +6,7 @@ build:
 	docker build -t $(NAME) .
 
 run: build
-	docker run -it --rm --env-file ./.env $(NAME)
+	docker run -it --rm --env-file .env $(NAME)
 
 dev: build
-	docker run -v $(PWD):/app -it --rm --env-file ./.env $(NAME)
+	docker run -v $(PWD):/app -it --rm --env-file .env $(NAME) bash

--- a/kubernetes/cronjob.yaml
+++ b/kubernetes/cronjob.yaml
@@ -12,7 +12,7 @@ spec:
         spec:
           containers:
           - name: mrr-forecaster
-            image: julheimer/mrr_forecaster:0.1.0
+            image: bufferapp/mrr-forecaster:0.1.0
             env:
               - name: REDSHIFT_DB_NAME
                 valueFrom:


### PR DESCRIPTION
Hey there @jwinternheimer! After some tweaking I think we have a working Dockerfile. 

Although the base image is now fixed to `rocker/tidyverse:3.5` the dependencies might vary in the future and I haven't found a way to freeze the versions.

That said, I feel good to move forward with this one! Besides that, I've renamed the image to `bufferapp/mrr-forecaster:0.1.0` so we can pull it from the Kubernetes cluster.

This PR closes https://github.com/bufferapp/mrr-forecaster/issues/6!